### PR TITLE
Displays the time since the last post and not since the topic creation

### DIFF
--- a/static/templates/partials/nodebb-plugin-recent-cards/header.tpl
+++ b/static/templates/partials/nodebb-plugin-recent-cards/header.tpl
@@ -28,7 +28,7 @@
 				<div class="category-info" style="color: {topics.category.color};">
 					<a href="{config.relative_path}/topic/{topics.slug}" itemprop="url" style="color: {topics.category.color};">
 						<h4><!-- IF topics.category.icon --><i class="fa {topics.category.icon} visible-xs-inline"></i> <!-- ENDIF topics.category.icon -->{topics.title}</h4>
-						<div class="description" itemprop="description"><strong>{topics.category.name}</strong> <span class="timeago" title="{topics.relativeTime}"></div>
+						<div class="description" itemprop="description"><strong>{topics.category.name}</strong> <span class="timeago" title="{topics.teaser.timestamp}"></div>
 					</a>
 				</div>
 			</div>


### PR DESCRIPTION
I think it would be more logical to display to time elapsed since the last post, not the topic creation (I hope it is the right way to implement it).

Anyway, thanks for this plugin.